### PR TITLE
Add function to change I2C address of TMF8801

### DIFF
--- a/src/107-Arduino-TMF8801.cpp
+++ b/src/107-Arduino-TMF8801.cpp
@@ -140,7 +140,7 @@ void ArduinoTMF8801::stop_continuous_measurement()
   _io.write(TMF8801::Register::COMMAND,   TMF8801::to_integer(TMF8801::COMMAND::STOP_CONTINUOUS_MEASUREMENT)); /* Set flag to stop everything */
 }
 
-void ArduinoTMF8801::change_i2c_address(uint8_t new_address)
+void ArduinoTMF8801::change_i2c_address(uint8_t const new_address)
 {
   new_address = new_address & 0x7F; /* set bit7 to 0 */
   uint8_t new_address_buf = new_address << 1;   /* shift one bit */
@@ -150,8 +150,6 @@ void ArduinoTMF8801::change_i2c_address(uint8_t new_address)
   _io.write(TMF8801::Register::COMMAND,   TMF8801::to_integer(TMF8801::COMMAND::CHANGE_I2C_ADDRESS)); /* Set flag to change i2c address */
 
   _io.change_i2c_slace_addr(new_address);
-  Serial.print("STATUS = 0x");
-  Serial.println(_io.read(TMF8801::Register::STATUS), HEX);
 }
 
 void ArduinoTMF8801::onExternalEventHandler()

--- a/src/107-Arduino-TMF8801.cpp
+++ b/src/107-Arduino-TMF8801.cpp
@@ -142,11 +142,10 @@ void ArduinoTMF8801::stop_continuous_measurement()
 
 void ArduinoTMF8801::change_i2c_address(uint8_t const new_address)
 {
-  new_address = new_address & 0x7F; /* set bit7 to 0 */
-  uint8_t new_address_buf = new_address << 1;   /* shift one bit */
-  new_address_buf = new_address_buf & 0xFE; /* set bit0 to 0 */
+  uint8_t new_address_buf = (new_address & 0x7F) << 1;    /* Shift one bit */
+  new_address_buf = new_address_buf & 0xFE;               /* Set Bit 0 to 0 */
   _io.write(TMF8801::Register::CMD_DATA1, new_address_buf);
-  _io.write(TMF8801::Register::CMD_DATA0, 0x00); /* Needs to be always 00 */
+  _io.write(TMF8801::Register::CMD_DATA0, 0x00);          /* Needs to be always 0 */
   _io.write(TMF8801::Register::COMMAND,   TMF8801::to_integer(TMF8801::COMMAND::CHANGE_I2C_ADDRESS)); /* Set flag to change i2c address */
 
   _io.set_i2c_slace_addr(new_address);

--- a/src/107-Arduino-TMF8801.cpp
+++ b/src/107-Arduino-TMF8801.cpp
@@ -140,6 +140,20 @@ void ArduinoTMF8801::stop_continuous_measurement()
   _io.write(TMF8801::Register::COMMAND,   TMF8801::to_integer(TMF8801::COMMAND::STOP_CONTINUOUS_MEASUREMENT)); /* Set flag to stop everything */
 }
 
+void ArduinoTMF8801::change_i2c_address(uint8_t new_address)
+{
+  new_address = new_address & 0x7F; /* set bit7 to 0 */
+  uint8_t new_address_buf = new_address << 1;   /* shift one bit */
+  new_address_buf = new_address_buf & 0xFE; /* set bit0 to 0 */
+  _io.write(TMF8801::Register::CMD_DATA1, new_address_buf);
+  _io.write(TMF8801::Register::CMD_DATA0, 0x00); /* Needs to be always 00 */
+  _io.write(TMF8801::Register::COMMAND,   TMF8801::to_integer(TMF8801::COMMAND::CHANGE_I2C_ADDRESS)); /* Set flag to change i2c address */
+
+  _io.change_i2c_slace_addr(new_address);
+  Serial.print("STATUS = 0x");
+  Serial.println(_io.read(TMF8801::Register::STATUS), HEX);
+}
+
 void ArduinoTMF8801::onExternalEventHandler()
 {
   /* Clear the interrupt flag. */

--- a/src/107-Arduino-TMF8801.cpp
+++ b/src/107-Arduino-TMF8801.cpp
@@ -149,7 +149,7 @@ void ArduinoTMF8801::change_i2c_address(uint8_t const new_address)
   _io.write(TMF8801::Register::CMD_DATA0, 0x00); /* Needs to be always 00 */
   _io.write(TMF8801::Register::COMMAND,   TMF8801::to_integer(TMF8801::COMMAND::CHANGE_I2C_ADDRESS)); /* Set flag to change i2c address */
 
-  _io.change_i2c_slace_addr(new_address);
+  _io.set_i2c_slace_addr(new_address);
 }
 
 void ArduinoTMF8801::onExternalEventHandler()

--- a/src/107-Arduino-TMF8801.h
+++ b/src/107-Arduino-TMF8801.h
@@ -59,6 +59,7 @@ public:
   void     set_gpio(TMF8801::GPIO const gpio);
   void     clr_gpio(TMF8801::GPIO const gpio);
   void     stop_continuous_measurement();
+  void     change_i2c_address(uint8_t const new_address);
 
   void onExternalEventHandler();
 

--- a/src/TMF8801/TMF8801_Const.h
+++ b/src/TMF8801/TMF8801_Const.h
@@ -125,6 +125,7 @@ enum class COMMAND : uint8_t
   DOWNLOAD_CALIB_AND_STATE    = 0x0B,
   SET_GPIO_CONTROL_SETTING    = 0x0F, /* Set gpio control setting without actually performing a measurement as commands 0x02 or 0x03 would do */
   SERIAL_NUMBER_READOUT       = 0x47, /* Read out serial number  */
+  CHANGE_I2C_ADDRESS          = 0x49, /* Change the I2C address of TMF8801  */
   STOP_CONTINUOUS_MEASUREMENT = 0xFF, /* Stop whatever you are doing as soon as possible and reenter the idle
 state */
 };

--- a/src/TMF8801/TMF8801_Io.cpp
+++ b/src/TMF8801/TMF8801_Io.cpp
@@ -72,10 +72,6 @@ bool TMF8801_Io::isBitSet(Register const reg, uint8_t const bitpos)
   else
     return false;
 }
-void TMF8801_Io::change_i2c_slace_addr (uint8_t const new_i2c_slave_addr)
-{
-  _i2c_slave_addr = new_i2c_slave_addr;
-}
 
 /**************************************************************************************
  * NAMESPACE

--- a/src/TMF8801/TMF8801_Io.cpp
+++ b/src/TMF8801/TMF8801_Io.cpp
@@ -72,6 +72,10 @@ bool TMF8801_Io::isBitSet(Register const reg, uint8_t const bitpos)
   else
     return false;
 }
+void TMF8801_Io::change_i2c_slace_addr (uint8_t const new_i2c_slave_addr)
+{
+  _i2c_slave_addr = new_i2c_slave_addr;
+}
 
 /**************************************************************************************
  * NAMESPACE

--- a/src/TMF8801/TMF8801_Io.h
+++ b/src/TMF8801/TMF8801_Io.h
@@ -43,13 +43,15 @@ public:
   TMF8801_Io(I2cWriteFunc write, I2cReadFunc read, uint8_t const i2c_slave_addr);
 
 
+  inline void set_i2c_slace_addr(uint8_t const i2c_slave_addr) { _i2c_slave_addr = i2c_slave_addr; }
+
+
   uint8_t read    (Register const reg);
   void    write   (Register const reg, uint8_t const val);
   void    read    (Register const reg, uint8_t * buf, size_t const bytes);
   void    write   (Register const reg, uint8_t const * buf, size_t const bytes);
   void    modify  (Register const reg, uint8_t const bitmask, uint8_t const val);
   bool    isBitSet(Register const reg, uint8_t const bitpos);
-  void    change_i2c_slace_addr (uint8_t const new_i2c_slave_addr);
 
 
 private:

--- a/src/TMF8801/TMF8801_Io.h
+++ b/src/TMF8801/TMF8801_Io.h
@@ -49,6 +49,7 @@ public:
   void    write   (Register const reg, uint8_t const * buf, size_t const bytes);
   void    modify  (Register const reg, uint8_t const bitmask, uint8_t const val);
   bool    isBitSet(Register const reg, uint8_t const bitpos);
+  void    change_i2c_slace_addr (uint8_t const new_i2c_slave_addr);
 
 
 private:
@@ -56,7 +57,7 @@ private:
   I2cWriteFunc _write;
   I2cReadFunc _read;
 
-  uint8_t const _i2c_slave_addr;
+  uint8_t _i2c_slave_addr;
 };
 
 /**************************************************************************************


### PR DESCRIPTION
Add function to change I2C address of TMF8801

Attention: does not work with TMF8801 out of the box. You first have to update the RAM firmware of TMF8801 as described in the datasheet.